### PR TITLE
Add babel-preset-expo to devDependencies

### DIFF
--- a/focus-flow/package.json
+++ b/focus-flow/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
+    "babel-preset-expo": "~12.0.6",
     "typescript": "~5.9.2"
   },
   "private": true


### PR DESCRIPTION
The babel-preset-expo package needs to be explicitly listed as a devDependency for Vercel builds. It was previously installed as a transitive dependency locally but Vercel requires it to be explicit.

This fixes the build error:
"Cannot find module 'babel-preset-expo'"

🤖 Generated with [Claude Code](https://claude.com/claude-code)