### PR TITLE
Fix template string syntax in projects.tsx

### DIFF
--- a/focus-flow/app/(tabs)/projects.tsx
+++ b/focus-flow/app/(tabs)/projects.tsx
@@ -81,7 +81,7 @@ export default function ProjectsScreen() {
             borderColor: colors.separator,
           },
         ]}
-        onPress={() => router.push(\/project/${item.id}`)}`
+        onPress={() => router.push(`/project/${item.id}`)}
         activeOpacity={0.7}
       >
         <View style={[styles.colorBar, { backgroundColor: item.color }]} />


### PR DESCRIPTION
Fixed malformed template literal at line 84. Changed from:
  onPress={() => router.push(\/project/${item.id}\`))}\`
To:
  onPress={() => router.push(\`/project/${item.id}\`)}

This fixes the Vercel build error:
"Expecting Unicode escape sequence \uXXXX"

🤖 Generated with [Claude Code](https://claude.com/claude-code)