### PR TITLE
Add Stack navigation for task and project detail screens

### DIFF
--- a/focus-flow/app/_layout.tsx
+++ b/focus-flow/app/_layout.tsx
@@ -43,6 +43,20 @@ export default function RootLayout() {
         }}
       >
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="task/[id]"
+          options={{
+            headerShown: false,
+            presentation: 'card'
+          }}
+        />
+        <Stack.Screen
+          name="project/[id]"
+          options={{
+            headerShown: false,
+            presentation: 'card'
+          }}
+        />
       </Stack>
     </GestureHandlerRootView>
   );


### PR DESCRIPTION
Fix blank project/task detail screens by registering the dynamic routes in the root Stack navigator. This ensures the routes are properly handled when navigating to /task/[id] and /project/[id].

🤖 Generated with [Claude Code](https://claude.com/claude-code)