### PR TITLE
Downgrade date-fns to v2 to fix import.meta error

### DIFF
--- a/focus-flow/package.json
+++ b/focus-flow/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.2.0",
-    "date-fns": "^4.1.0",
+    "date-fns": "^2.30.0",
     "expo": "~54.0.20",
     "expo-constants": "^18.0.10",
     "expo-linking": "^8.0.8",


### PR DESCRIPTION
date-fns v4 uses import.meta which causes build errors in web bundle. Downgraded to v2.30.0 which is stable and compatible with Expo web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)