### PR TITLE
Downgrade to Expo SDK 51 for better web build stability

### DIFF
--- a/focus-flow/package.json
+++ b/focus-flow/package.json
@@ -11,26 +11,26 @@
     "vercel-build": "expo export -p web"
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^2.2.0",
-    "expo": "~54.0.20",
-    "expo-constants": "^18.0.10",
-    "expo-linking": "^8.0.8",
-    "expo-router": "^6.0.13",
-    "expo-status-bar": "~3.0.8",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
-    "react-native": "0.81.5",
-    "react-native-gesture-handler": "^2.29.0",
-    "react-native-safe-area-context": "^5.6.1",
-    "react-native-screens": "^4.18.0",
-    "react-native-svg": "^15.14.0",
-    "react-native-web": "~0.19.13",
+    "@react-native-async-storage/async-storage": "1.23.1",
+    "expo": "~51.0.0",
+    "expo-constants": "~16.0.0",
+    "expo-linking": "~6.3.0",
+    "expo-router": "~3.5.0",
+    "expo-status-bar": "~1.12.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.74.5",
+    "react-native-gesture-handler": "~2.16.1",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "3.31.1",
+    "react-native-svg": "15.2.0",
+    "react-native-web": "~0.19.10",
     "zustand": "^4.5.5"
   },
   "devDependencies": {
-    "@types/react": "~19.1.0",
-    "babel-preset-expo": "~12.0.6",
-    "typescript": "~5.9.2"
+    "@types/react": "~18.2.45",
+    "babel-preset-expo": "~11.0.0",
+    "typescript": "~5.3.0"
   },
   "private": true
 }


### PR DESCRIPTION
Expo SDK 54 has issues with import.meta in web builds. Downgrading to SDK 51 which is more stable and has better web compatibility.

Changes:
- Expo: 54.0.20 → 51.0.0
- React: 19.0.0 → 18.2.0
- React Native: 0.81.5 → 0.74.5
- Expo Router: 6.0.13 → 3.5.0
- All supporting packages downgraded to SDK 51 compatible versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)