### PR TITLE
Fix all remaining date-fns imports in TaskRow and sampleData

### DIFF
--- a/focus-flow/src/components/TaskRow.tsx
+++ b/focus-flow/src/components/TaskRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Pressable } from 'react-native';
 import { Task } from '../types';
 import { useTheme } from '../theme/useTheme';
-import { format } from 'date-fns';
+import { formatDate } from '../utils/dateUtils';
 
 interface TaskRowProps {
   task: Task;
@@ -97,14 +97,14 @@ export const TaskRow: React.FC<TaskRowProps> = ({ task, onPress, onToggleComplet
             {task.dueDate && (
               <View style={[styles.badge, { backgroundColor: colors.secondaryBackground }]}>
                 <Text style={[styles.badgeText, { color: colors.secondaryText, ...typography.caption1 }]}>
-                  Due: {format(task.dueDate, 'MMM d')}
+                  Due: {formatDate(task.dueDate, 'MMM d')}
                 </Text>
               </View>
             )}
             {task.plannedDate && (
               <View style={[styles.badge, { backgroundColor: colors.secondaryBackground }]}>
                 <Text style={[styles.badgeText, { color: colors.secondaryText, ...typography.caption1 }]}>
-                  Planned: {format(task.plannedDate, 'MMM d')}
+                  Planned: {formatDate(task.plannedDate, 'MMM d')}
                 </Text>
               </View>
             )}

--- a/focus-flow/src/utils/dateUtils.ts
+++ b/focus-flow/src/utils/dateUtils.ts
@@ -5,6 +5,7 @@ export const formatDate = (date: Date, formatStr: string): string => {
   const fullMonths = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
   if (formatStr === 'd') return String(date.getDate());
+  if (formatStr === 'MMM d') return `${months[date.getMonth()]} ${date.getDate()}`;
   if (formatStr === 'MMM d, yyyy') return `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
   if (formatStr === 'MMMM yyyy') return `${fullMonths[date.getMonth()]} ${date.getFullYear()}`;
   return date.toLocaleDateString();

--- a/focus-flow/src/utils/sampleData.ts
+++ b/focus-flow/src/utils/sampleData.ts
@@ -1,5 +1,5 @@
 import { Task, Project, FocusArea, TaskStatus, TaskPriority } from '../types';
-import { addDays, subDays } from 'date-fns';
+import { addDays, subDays } from './dateUtils';
 
 export const sampleFocusAreas: Omit<FocusArea, 'id' | 'createdAt' | 'updatedAt' | 'order'>[] = [
   {


### PR DESCRIPTION
Replaced all remaining date-fns imports with native date utilities:
- Updated TaskRow.tsx to use formatDate from dateUtils
- Updated sampleData.ts to use addDays/subDays from dateUtils
- Added 'MMM d' format support to formatDate function

This completes the removal of date-fns dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)