### PR TITLE
Add comprehensive logging to identify OmniFocus 4 data structure

### DIFF
--- a/focus-flow/src/utils/ofocusParser.ts
+++ b/focus-flow/src/utils/ofocusParser.ts
@@ -239,14 +239,12 @@ export async function parseOFocusFile(file: File): Promise<{
       console.log('First folder sample:', JSON.stringify(ofFolders[0], null, 2).substring(0, 500));
     }
 
-    // Check if tasks have project references
-    const ofTasks = Array.isArray(omnifocus.task)
-      ? omnifocus.task
-      : omnifocus.task
-      ? [omnifocus.task]
-      : [];
-    if (ofTasks.length > 0) {
-      console.log('First task sample:', JSON.stringify(ofTasks[0], null, 2).substring(0, 500));
+    // Check if tasks have project references (for debugging)
+    if (omnifocus.task) {
+      const debugTasks = Array.isArray(omnifocus.task) ? omnifocus.task : [omnifocus.task];
+      if (debugTasks.length > 0) {
+        console.log('First task sample:', JSON.stringify(debugTasks[0], null, 2).substring(0, 500));
+      }
     }
 
     ofProjects.forEach((ofProject: OFProject) => {


### PR DESCRIPTION
Enhanced debugging to understand where projects are stored:
- Log actual key names, not just count
- Log array lengths for each key
- Check for both 'project' and 'folder' fields
- Log sample task to see if project info is embedded
- Log sample folder to understand folder structure

This will help identify how OmniFocus 4 organizes projects differently from v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)