### PR TITLE
Add debugging to understand OmniFocus 4 task-project structure

### DIFF
--- a/focus-flow/src/utils/ofocusParser.ts
+++ b/focus-flow/src/utils/ofocusParser.ts
@@ -277,16 +277,20 @@ export async function parseOFocusFile(file: File): Promise<{
           projectMap.set(item['@_id'], projectName);
         }
 
+        // Debug: Check what the task field looks like
+        console.log(`Project "${projectName}" task field:`, typeof item.task, item.task ? (Array.isArray(item.task) ? `Array(${item.task.length})` : JSON.stringify(item.task).substring(0, 100)) : 'undefined');
+
         // Process child tasks within this project
-        if (item.task) {
+        if (item.task && item.task !== '') {
           const projectTasks = Array.isArray(item.task) ? item.task : [item.task];
+          console.log(`  Processing ${projectTasks.length} child tasks for project "${projectName}"`);
           projectTasks.forEach((childTask: any) => {
             // Recursively process child tasks (they might have their own children)
             const processTask = (task: any, parentProjectName: string) => {
               tasks.push(convertOFTask(task, parentProjectName));
 
               // If this task has children, process them too
-              if (task.task) {
+              if (task.task && task.task !== '') {
                 const childTasks = Array.isArray(task.task) ? task.task : [task.task];
                 childTasks.forEach((child: any) => processTask(child, parentProjectName));
               }
@@ -302,10 +306,18 @@ export async function parseOFocusFile(file: File): Promise<{
     console.log(`Identified ${projects.length} projects with ${tasksInProjects} tasks`);
 
     // Second pass: process regular tasks (inbox items, orphaned tasks)
+    let debuggedTask = false;
     allTasks.forEach((item: any) => {
       // Skip items that are projects
       if (item.project && typeof item.project === 'object') {
         return;
+      }
+
+      // Debug first non-project task to see its structure
+      if (!debuggedTask) {
+        console.log('Sample non-project task fields:', Object.keys(item).join(', '));
+        console.log('Sample task detail:', JSON.stringify(item, null, 2).substring(0, 800));
+        debuggedTask = true;
       }
 
       // This is a regular task (inbox item or standalone task)


### PR DESCRIPTION
Current issue: Projects are identified but 0 tasks are being linked to them. All 1472 tasks are being treated as inbox items.

Added debugging to investigate:
- Log each project's task field (type and value)
- Log count of child tasks found per project
- Log fields and structure of first non-project task
- Check if tasks have empty string vs undefined vs actual data

This will help understand how OmniFocus 4 actually links tasks to projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)