### PR TITLE
Remove completion rate and add task flagging feature

### DIFF
--- a/focus-flow/app/(tabs)/index.tsx
+++ b/focus-flow/app/(tabs)/index.tsx
@@ -55,6 +55,10 @@ export default function DashboardScreen() {
       (p) => p.status === 'in-progress' || p.status === 'todo'
     );
 
+    const flaggedTasks = tasks.filter(
+      (t) => t.isFlagged && t.status !== 'completed'
+    );
+
     return {
       totalTasks,
       completedTasks,
@@ -63,6 +67,7 @@ export default function DashboardScreen() {
       dueTodayTasks,
       upcomingTasks,
       activeProjects,
+      flaggedTasks,
       completionRate: totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0,
     };
   }, [tasks, projects]);
@@ -184,7 +189,6 @@ export default function DashboardScreen() {
           {renderStatCard('Total Tasks', stats.totalTasks, colors.blue)}
           {renderStatCard('Completed', stats.completedTasks, colors.green)}
           {renderStatCard('In Progress', stats.inProgressTasks, colors.orange)}
-          {renderStatCard('Completion Rate (All Time)', `${stats.completionRate}%`, colors.purple)}
         </View>
 
         {/* Daily Focus Section */}
@@ -258,6 +262,30 @@ export default function DashboardScreen() {
                   </Text>
                 </TouchableOpacity>
               ))}
+            </View>
+          </View>
+        )}
+
+        {/* Flagged Tasks Section */}
+        {stats.flaggedTasks.length > 0 && (
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Text style={[styles.sectionTitle, { color: colors.text, ...typography.title2 }]}>
+                ⭐ Flagged ({stats.flaggedTasks.length})
+              </Text>
+            </View>
+            <View style={[styles.sectionContent, { backgroundColor: colors.secondaryBackground }]}>
+              {stats.flaggedTasks.slice(0, 5).map((task) => renderTaskRow(task))}
+              {stats.flaggedTasks.length > 5 && (
+                <TouchableOpacity
+                  style={styles.viewAllButton}
+                  onPress={() => router.push('/tasks')}
+                >
+                  <Text style={[styles.viewAllText, { color: colors.primary, ...typography.caption1 }]}>
+                    View all {stats.flaggedTasks.length} flagged tasks
+                  </Text>
+                </TouchableOpacity>
+              )}
             </View>
           </View>
         )}

--- a/focus-flow/app/(tabs)/tasks.tsx
+++ b/focus-flow/app/(tabs)/tasks.tsx
@@ -30,6 +30,7 @@ export default function TasksScreen() {
   const tasks = useTaskStore((state) => state.tasks);
   const addTask = useTaskStore((state) => state.addTask);
   const toggleTaskComplete = useTaskStore((state) => state.toggleTaskComplete);
+  const toggleTaskFlag = useTaskStore((state) => state.toggleTaskFlag);
   const deleteTask = useTaskStore((state) => state.deleteTask);
   const loadData = useTaskStore((state) => state.loadData);
   const projects = useTaskStore((state) => state.projects);
@@ -42,6 +43,7 @@ export default function TasksScreen() {
   const [sortBy, setSortBy] = useState<'date' | 'priority' | 'title'>('date');
   const [showSortMenu, setShowSortMenu] = useState(false);
   const [hideCompleted, setHideCompleted] = useState(false);
+  const [showOnlyFlagged, setShowOnlyFlagged] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
   const [newTask, setNewTask] = useState({
@@ -75,6 +77,9 @@ export default function TasksScreen() {
 
   const filteredTasks = tasks
     .filter((task) => {
+      // Show only flagged filter
+      if (showOnlyFlagged && !task.isFlagged) return false;
+
       // Hide completed filter
       if (hideCompleted && task.status === 'completed') return false;
 
@@ -195,6 +200,22 @@ export default function TasksScreen() {
             </Text>
           </TouchableOpacity>
 
+          <TouchableOpacity
+            style={[
+              styles.sortButton,
+              {
+                backgroundColor: showOnlyFlagged ? colors.primary : colors.secondaryBackground,
+                borderColor: colors.separator,
+                marginLeft: 8,
+              }
+            ]}
+            onPress={() => setShowOnlyFlagged(!showOnlyFlagged)}
+          >
+            <Text style={[styles.sortButtonText, { color: showOnlyFlagged ? '#FFFFFF' : colors.text, ...typography.subheadline }]}>
+              {showOnlyFlagged ? '⭐ All' : '⭐ Flagged'}
+            </Text>
+          </TouchableOpacity>
+
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
@@ -262,6 +283,7 @@ export default function TasksScreen() {
             task={item}
             onPress={() => router.push(`/task/${item.id}`)}
             onToggleComplete={() => toggleTaskComplete(item.id)}
+            onToggleFlag={() => toggleTaskFlag(item.id)}
             onDelete={() => deleteTask(item.id)}
             density={viewDensity}
           />

--- a/focus-flow/src/components/TaskRow.tsx
+++ b/focus-flow/src/components/TaskRow.tsx
@@ -11,11 +11,12 @@ interface TaskRowProps {
   task: Task;
   onPress: () => void;
   onToggleComplete: () => void;
+  onToggleFlag?: () => void;
   onDelete?: () => void;
   density?: ViewDensity;
 }
 
-export const TaskRow: React.FC<TaskRowProps> = ({ task, onPress, onToggleComplete, onDelete, density = 'comfortable' }) => {
+export const TaskRow: React.FC<TaskRowProps> = ({ task, onPress, onToggleComplete, onToggleFlag, onDelete, density = 'comfortable' }) => {
   const { colors, typography, spacing, borderRadius, shadow } = useTheme();
 
   // Calculate spacing based on view density
@@ -241,6 +242,23 @@ export const TaskRow: React.FC<TaskRowProps> = ({ task, onPress, onToggleComplet
               >
                 {task.title}
               </Text>
+              {onToggleFlag && (
+                <TouchableOpacity
+                  onPress={() => {
+                    haptics.light();
+                    onToggleFlag();
+                  }}
+                  style={styles.flagButton}
+                  accessible={true}
+                  accessibilityRole="button"
+                  accessibilityLabel={task.isFlagged ? 'Unflag task' : 'Flag task'}
+                  accessibilityHint="Double tap to toggle flag status"
+                >
+                  <Text style={[styles.flagIcon, { fontSize: densitySpacing.checkboxSize }]}>
+                    {task.isFlagged ? '⭐' : '☆'}
+                  </Text>
+                </TouchableOpacity>
+              )}
               <View
                 style={[
                   styles.priorityIndicator,
@@ -337,6 +355,14 @@ const styles = StyleSheet.create({
     height: 6,
     borderRadius: 3,
     marginTop: 5,
+  },
+  flagButton: {
+    paddingHorizontal: 4,
+    marginRight: 4,
+    marginTop: -2,
+  },
+  flagIcon: {
+    color: '#FFD700',
   },
   metadata: {
     flexDirection: 'row',

--- a/focus-flow/src/store/taskStore.ts
+++ b/focus-flow/src/store/taskStore.ts
@@ -17,6 +17,7 @@ interface TaskStore {
   updateTask: (id: string, updates: Partial<Task>) => void;
   deleteTask: (id: string) => void;
   toggleTaskComplete: (id: string) => void;
+  toggleTaskFlag: (id: string) => void;
   bulkAddTasks: (tasks: Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'progress' | 'order' | 'dependsOn' | 'blockedBy' | 'tags'>[]) => void;
 
   // Project actions
@@ -101,6 +102,21 @@ export const useTaskStore = create<TaskStore>((set, get) => ({
               status: task.status === 'completed' ? 'todo' : 'completed',
               completedDate: task.status === 'completed' ? undefined : new Date(),
               progress: task.status === 'completed' ? 0 : 100,
+              updatedAt: new Date(),
+            }
+          : task
+      ),
+    }));
+    get().saveData();
+  },
+
+  toggleTaskFlag: (id) => {
+    set((state) => ({
+      tasks: state.tasks.map((task) =>
+        task.id === id
+          ? {
+              ...task,
+              isFlagged: !task.isFlagged,
               updatedAt: new Date(),
             }
           : task

--- a/focus-flow/src/types/index.ts
+++ b/focus-flow/src/types/index.ts
@@ -19,6 +19,7 @@ export interface Task {
   priority: TaskPriority;
   projectId?: string;
   focusAreaId?: string;
+  isFlagged?: boolean; // Star/flag important tasks
 
   // Dependencies
   dependsOn: string[]; // IDs of tasks this task depends on


### PR DESCRIPTION
Three major changes:

1. Removed completion rate stat from dashboard
   - Removed "Completion Rate (All Time)" card from stats grid
   - Simplified dashboard to show only: Total, Completed, In Progress

2. Added task flagging/starring feature
   - New isFlagged boolean field in Task type
   - toggleTaskFlag action in taskStore to toggle flag status
   - Flag icon (⭐/☆) in TaskRow component with tap-to-toggle
   - Haptic feedback when toggling flag
   - Gold colored star icon for visual prominence

3. Added flagged tasks section and filter
   - New "⭐ Flagged" section on dashboard showing incomplete flagged tasks
   - Shows first 5 flagged tasks with "View all" link
   - Appears after Daily Focus and before Overdue sections
   - Added "⭐ Flagged" filter button in tasks screen
   - Filter shows only flagged tasks when active
   - Works alongside existing filters (status, hide completed, search)

Implementation details:
- Flag toggle fully accessible with VoiceOver support
- Flag status persists in AsyncStorage via taskStore
- Flag icon size adjusts based on view density setting
- Flagged tasks exclude completed tasks in dashboard
- All changes follow existing design patterns and Apple HIG